### PR TITLE
Add zellij terminal multiplexer

### DIFF
--- a/modules/packages/default.nix
+++ b/modules/packages/default.nix
@@ -22,6 +22,9 @@
     htop
     btop
 
+    # Terminal multiplexer
+    zellij
+
     # Git tools
     lazygit
     gh


### PR DESCRIPTION
Closes #13

This PR adds **zellij** as a modern terminal multiplexer alternative to tmux/screen.