### PR TITLE
Set bash as default shell

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -9,6 +9,7 @@
   # Set NIX_HOME_TARGET so 'apply' command knows which config to use
   home.sessionVariables = {
     NIX_HOME_TARGET = configName;
+    SHELL = "${pkgs.bash}/bin/bash";
   };
 
   # Module imports
@@ -17,5 +18,6 @@
     ./modules/bash/default.nix
     ./modules/packages/default.nix
     ./modules/ui/fonts.nix
+    ./modules/terminal/zellij.nix
   ];
 }

--- a/modules/packages/default.nix
+++ b/modules/packages/default.nix
@@ -22,9 +22,6 @@
     htop
     btop
 
-    # Terminal multiplexer
-    zellij
-
     # Git tools
     lazygit
     gh

--- a/modules/terminal/zellij.nix
+++ b/modules/terminal/zellij.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }: {
+  programs.zellij = {
+    enable = true;
+    settings = {
+      default_shell = "${pkgs.bash}/bin/bash";
+    };
+  };
+}


### PR DESCRIPTION
Closes #17

This PR:
- Sets `SHELL` environment variable to bash
- Configures zellij to use bash as default shell instead of sh
- Moves zellij from packages to its own module in `modules/terminal/`