### PR TITLE
Enable bash completion

### DIFF
--- a/modules/bash/default.nix
+++ b/modules/bash/default.nix
@@ -12,6 +12,11 @@ in
     ./tools/fzf.nix
   ];
 
+  # Bash completion package
+  home.packages = with pkgs; [
+    bash-completion
+  ];
+
   programs.bash = {
     enable = true;
     enableCompletion = true;


### PR DESCRIPTION
Closes #25

This PR enables bash completion by setting `enableCompletion = true` in the bash module.

Home-manager will automatically install and configure bash-completion, providing better tab completion for commands and their arguments.