### PR TITLE
Add cspell for spell checking

### DIFF
--- a/modules/nvim/packages/tools.nix
+++ b/modules/nvim/packages/tools.nix
@@ -10,5 +10,8 @@
 
   # Node.js (required for Copilot)
   nodejs
+
+  # Spell checker
+  cspell
 ]
 

--- a/modules/nvim/plugins/core.nix
+++ b/modules/nvim/plugins/core.nix
@@ -89,6 +89,15 @@
         capabilities = capabilities,
       }
       vim.lsp.enable("lua_ls")
+
+      -- CSpell
+      vim.lsp.config.cspell = {
+        cmd = { "cspell-lsp", "--stdio" },
+        filetypes = { "markdown", "text", "gitcommit", "nix", "lua", "typescript", "javascript", "python" },
+        root_markers = { ".git", "cspell.json", ".cspell.json" },
+        capabilities = capabilities,
+      }
+      vim.lsp.enable("cspell")
     '';
   }
 ]


### PR DESCRIPTION
Closes #26

This PR adds [CSpell](https://cspell.org/) for advanced spell checking in neovim:
- ✅ Added cspell package to nvim tools
- ✅ Configured cspell as LSP server
- ✅ Enabled for markdown, text, code files (nix, lua, typescript, javascript, python)
- Works via LSP diagnostics and code actions