### PR TITLE
Add markdown support plugins

### DIFF
--- a/modules/nvim/Manual.md
+++ b/modules/nvim/Manual.md
@@ -12,8 +12,10 @@
 - [File Explorer](#file-explorer)
 - [Search and Navigation](#search-and-navigation)
 - [Editing](#editing)
+- [Markdown](#markdown)
 - [Notifications and Messages](#notifications-and-messages)
 - [Spell Checking](#spell-checking)
+- [Commands](#commands)
 - [Key Notation Reference](#key-notation-reference)
 
 ---
@@ -143,6 +145,15 @@
 | `J` | Move selected line(s) down |
 | `K` | Move selected line(s) up |
 
+## Markdown
+
+| Keybinding | Description |
+|------------|-------------|
+| `<leader>mr` | Toggle markdown render (render-markdown.nvim) |
+| `<leader>z` | Toggle zen mode (distraction-free writing) |
+| `<leader>mp` | Open markdown preview in browser |
+| `<leader>ms` | Stop markdown preview |
+
 ## Notifications and Messages
 
 | Keybinding | Description |
@@ -166,6 +177,40 @@ Neovim has built-in spell checking enabled for US English. Additionally, CSpell 
 | `[s` | Previous misspelled word |
 | `zg` | Add word to dictionary |
 | `zw` | Mark word as incorrect |
+
+## Commands
+
+Neovim commands are executed in normal mode by typing `:` followed by the command name and pressing Enter.
+
+### Custom Commands
+
+| Command | Description |
+|---------|-------------|
+| `:LazyGit` | Open LazyGit in a terminal window |
+| `:RenderMarkdown toggle` | Toggle markdown rendering on/off |
+| `:ZenMode` | Toggle zen mode for focused writing |
+| `:MarkdownPreview` | Open markdown preview in browser |
+| `:MarkdownPreviewStop` | Stop markdown preview server |
+| `:Telescope find_files` | Find files using Telescope |
+| `:Telescope live_grep` | Search text in files |
+| `:NvimTreeToggle` | Toggle file explorer |
+| `:ToggleTerm` | Toggle terminal window |
+
+### Built-in Commands
+
+| Command | Description |
+|---------|-------------|
+| `:w` | Save (write) current file |
+| `:q` | Quit current window |
+| `:wq` or `:x` | Save and quit |
+| `:q!` | Quit without saving |
+| `:e <file>` | Edit/open a file |
+| `:bn` | Next buffer |
+| `:bp` | Previous buffer |
+| `:bd` | Delete/close buffer |
+| `:split` or `:sp` | Split window horizontally |
+| `:vsplit` or `:vsp` | Split window vertically |
+| `:help <topic>` | Open help for a topic |
 
 ---
 

--- a/modules/nvim/plugins/languages.nix
+++ b/modules/nvim/plugins/languages.nix
@@ -11,5 +11,47 @@
       }
     '';
   }
+
+  # Markdown rendering
+  {
+    plugin = render-markdown-nvim;
+    type = "lua";
+    config = ''
+      require("render-markdown").setup {
+        file_types = { "markdown" },
+        render_modes = { "n", "c" },
+      }
+      vim.keymap.set("n", "<leader>mr", "<cmd>RenderMarkdown toggle<cr>", { desc = "Toggle markdown render" })
+    '';
+  }
+
+  # Zen mode for focused writing
+  {
+    plugin = zen-mode-nvim;
+    type = "lua";
+    config = ''
+      require("zen-mode").setup {
+        window = {
+          width = 0.85,
+          options = {
+            number = false,
+            relativenumber = false,
+          },
+        },
+      }
+      vim.keymap.set("n", "<leader>z", "<cmd>ZenMode<cr>", { desc = "Toggle zen mode" })
+    '';
+  }
+
+  # Markdown preview in browser
+  {
+    plugin = markdown-preview-nvim;
+    type = "lua";
+    config = ''
+      vim.g.mkdp_auto_close = 0
+      vim.keymap.set("n", "<leader>mp", "<cmd>MarkdownPreview<cr>", { desc = "Markdown preview" })
+      vim.keymap.set("n", "<leader>ms", "<cmd>MarkdownPreviewStop<cr>", { desc = "Stop markdown preview" })
+    '';
+  }
 ]
 


### PR DESCRIPTION
Closes #31

This PR adds comprehensive markdown support to Neovim:

## Plugins Added
- ✅ **render-markdown.nvim**: Enhanced markdown rendering with syntax highlighting
- ✅ **zen-mode.nvim**: Distraction-free writing mode
- ✅ **markdown-preview.nvim**: Live preview in browser

## Keybindings
- `<leader>mr` - Toggle markdown render
- `<leader>z` - Toggle zen mode
- `<leader>mp` - Open markdown preview in browser
- `<leader>ms` - Stop markdown preview

## Manual Updates
- ✅ Added Markdown section documenting all keybindings
- ✅ Added Commands section documenting custom and built-in commands
- Updated table of contents